### PR TITLE
Update Diego-SSH plugin listing to version 0.1.2

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -341,25 +341,25 @@ plugins:
     checksum: 7b4cde6f37f82277cf6075f7b87769917003a7f6
 - name: Diego-SSH
   description: Access Diego containers with SSH
-  version: 0.1.0
+  version: 0.1.2
   created: 2015-6-16
-  updated: 2015-6-16
+  updated: 2015-6-24
   authors:
   - name: Cloud Foundry
   homepage: https://github.com/cloudfoundry-incubator/diego-ssh
   binaries:
   - platform: osx
-    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.0/ssh-plugin-darwin-amd64
-    checksum: ab754acdf9588a4e6f651d5a1d0f6564d34ce8b8
+    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.2/ssh-plugin-darwin-amd64
+    checksum: 35b79fba136db08a3cd05000f3171d1e7fb330c6
   - platform: win32
-    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.0/ssh-plugin-win32
-    checksum: d75649f2cd1a45083a6468cb52b7452c75d6cbf8
+    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.2/ssh-plugin-win32.exe
+    checksum: 130b147799baeb8d10e219c0109de327394569c1
   - platform: win64
-    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.0/ssh-plugin-win64
-    checksum: 6ebb33850531117a96f904bcacdfda93e038bcf7
+    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.2/ssh-plugin-win64.exe
+    checksum: 02c5d3e40b109dbca27e189ea2447ac1138159d2
   - platform: linux32
-    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.0/ssh-plugin-linux-386
-    checksum: 07dea98838f0281d5184958a9f037a1712750efc
+    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.2/ssh-plugin-linux-386
+    checksum: 731be7b16b1d25869ffb7126adc84877e4792218
   - platform: linux64
-    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.0/ssh-plugin-linux-amd64
-    checksum: ec8825928ea0d5875ed6165effd9b91d2821d134
+    url: https://github.com/cloudfoundry-incubator/diego-ssh/releases/download/plugin-0.1.2/ssh-plugin-linux-amd64
+    checksum: 53417cb73876fbbda11f480a03e7179e23e0e4db


### PR DESCRIPTION
This updates the repo listing for the Diego-SSH plugin to version 0.1.2.