### PR TITLE
Update cf-download

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -361,17 +361,20 @@ plugins:
   - name: Jake Eden
     homepage: https://github.com/jeden25
     contact: jeden@us.ibm.com
+  - name: Ryan Soley
+    homepage: https://github.com/reSoley
+    contact: resoley@us.ibm.com
   homepage: https://github.com/ibmjstart/cf-download
   binaries:
   - platform: osx
     url: https://github.com/ibmjstart/cf-download/blob/master/binaries/darwin/amd64/cf-download?raw=true
-    checksum: d097b37657d814a4b934ae39e41fc61078630b49
+    checksum: c7ff94fafc7e04ee8253074c3928146fc7ac2b68 
   - platform: win64
     url: https://github.com/ibmjstart/cf-download/blob/master/binaries/windows/amd64/cf-download.exe?raw=true
-    checksum: 1d9a0e458f623d12c36669678b9a7b86387d8578
+    checksum: 66186de33a9c83d63f88ca0bf01ea4ced4bfecb4 
   - platform: linux64
     url: https://github.com/ibmjstart/cf-download/blob/master/binaries/linux/amd64/cf-download?raw=true
-    checksum: 793e68b97896be69f4b91aaa063d82609542f26d
+    checksum: 610b4dce0a05063ce880b1fa930091ac563fc081 
 - name: Scaleover
   description: Roll traffic from one app to another by scaling over time
   version: 1.0.4


### PR DESCRIPTION
Made a change to allow for multiple input paths at https://github.com/ibmjstart/cf-download. Updated the checksums to reflect changes.