### PR TITLE
Add update-cli plugin

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -1,5 +1,26 @@
 ---
 plugins:
+- name: update-cli
+  description: Update cloudfoundry/cli to the latest version
+  version: 0.1.1
+  created: 2016-10-21T00:00:00Z
+  updated: 2016-10-21T00:00:00Z
+  company: Rakuten
+  authors:
+  - name: Taichi Nakashima
+    homepage: https://github.com/tcnksm
+    contact: taichi.nakashima@rakuten.com
+  homepage: https://github.com/tcnksm/cf-plugin-update-cli
+  binaries:
+  - platform: osx
+    url: https://github.com/tcnksm/cf-plugin-update-cli/releases/download/0.1.1/cf-plugin-update-cli_darwin_amd64
+    checksum: 34ce1d76d1dd872096159dd2bdfa5b8cbaef4e24
+  - platform: win64
+    url: https://github.com/tcnksm/cf-plugin-update-cli/releases/download/0.1.1/cf-plugin-update-cli_windows_amd64.exe
+    checksum: 575fa3f122fb20db0bd95b908ca6f0d43b70b266
+  - platform: linux64
+    url: https://github.com/tcnksm/cf-plugin-update-cli/releases/download/0.1.1/cf-plugin-update-cli_linux_amd64
+    checksum: 2358f4b5c7f6b8664dd5d578cc24a6f4734b8119
 - name: antifreeze
   description: Detect if an app has unexpected ENV vars or services bound which are missing from the manifest
   version: 0.3.0

--- a/repo-index.yml
+++ b/repo-index.yml
@@ -386,13 +386,13 @@ plugins:
   binaries:
   - platform: osx
     url: https://github.com/ibmjstart/cf-download/blob/master/binaries/darwin/amd64/cf-download?raw=true
-    checksum: d097b37657d814a4b934ae39e41fc61078630b49
+    checksum: c7ff94fafc7e04ee8253074c3928146fc7ac2b68
   - platform: win64
     url: https://github.com/ibmjstart/cf-download/blob/master/binaries/windows/amd64/cf-download.exe?raw=true
-    checksum: 1d9a0e458f623d12c36669678b9a7b86387d8578
+    checksum: 610b4dce0a05063ce880b1fa930091ac563fc081
   - platform: linux64
     url: https://github.com/ibmjstart/cf-download/blob/master/binaries/linux/amd64/cf-download?raw=true
-    checksum: 793e68b97896be69f4b91aaa063d82609542f26d
+    checksum: 66186de33a9c83d63f88ca0bf01ea4ced4bfecb4
 - name: Scaleover
   description: Roll traffic from one app to another by scaling over time
   version: 1.0.4


### PR DESCRIPTION
Please add `update-cli` plugin (https://github.com/tcnksm/cf-plugin-update-cli)
It checks cloudfoundry/cli update and downloads if current installed version is not latest.  

We use it inside Rakuten for a while and works well. So we want to provide it to the community, too.

