### PR TITLE
bumps firehose plugin to 0.12.0

### DIFF
--- a/repo-index.yml
+++ b/repo-index.yml
@@ -502,9 +502,9 @@ plugins:
     checksum: 66b5c8bac00e17195afe9be8e987049226bcbc2c
 - name: Firehose Plugin
   description: This plugin allows you to connect to the firehose (CF admins only)
-  version: 0.11.0
+  version: 0.12.0
   created: 2015-09-09T00:00:00Z
-  updated: 2016-08-04T04:30:44Z
+  updated: 2017-03-24T02:11:56Z
   company:
   authors:
   - name: Johannes Tuchscherer
@@ -513,17 +513,17 @@ plugins:
   - name: Warren Fernandes
     homepage: https://github.com/wfernandes
     contact: warren.f.fernandes@gmail.com
-  homepage: http://github.com/cloudfoundry/firehose-plugin
+  homepage: http://github.com/cloudfoundry-community/firehose-plugin
   binaries:
   - platform: osx
-    url: https://github.com/cloudfoundry/firehose-plugin/releases/download/0.11.0/nozzle-plugin-darwin
-    checksum: ab2a2e0ddd3c5d405cb0bce2bd05709010e4fb92
+    url: https://github.com/cloudfoundry-community/firehose-plugin/releases/download/0.12.0/nozzle-plugin-darwin
+    checksum: 64365de9fd00e18fc4bbcb02dfc172e0a1a2cff8
   - platform: win64
-    url: https://github.com/cloudfoundry/firehose-plugin/releases/download/0.11.0/nozzle-plugin.exe
-    checksum: a83b2768c37778cd113c4373fdece9b6afeef836
+    url: https://github.com/cloudfoundry-community/firehose-plugin/releases/download/0.12.0/nozzle-plugin.exe
+    checksum: 74f0c6aaeace310565ceb8e76ca0d16cb1ef7bbc
   - platform: linux64
-    url: https://github.com/cloudfoundry/firehose-plugin/releases/download/0.11.0/nozzle-plugin-linux
-    checksum: 9fe7ea8439f89bb54adff3b12541799ed7d4de29
+    url: https://github.com/cloudfoundry-community/firehose-plugin/releases/download/0.12.0/nozzle-plugin-linux
+    checksum: 31d07b66bee543ec082a9c6e17073eddaab10afa
 - name: Cloud Deployment Plugin
   description: This plugin allows you to manage application deployment details and manifests in a github repo (like spring cloud config server for deployments)
   version: 1.0.1


### PR DESCRIPTION
`cf nozzle` and `cf app-nozzle` no longer filters envelopes of type `HttpStart` and `HttpStop` because they are not supported by Loggregator any more.